### PR TITLE
Node.js v14+サポート

### DIFF
--- a/_gc/srv/package.json
+++ b/_gc/srv/package.json
@@ -4,8 +4,8 @@
   "description": "server for Web GPIO/I2C API",
   "main": "srv.js",
   "dependencies": {
-    "gpio": "^0.2.10",
     "i2c-bus": "^5.0.0",
+    "onoff": "^6.0.3",
     "ws": "^7.1.2"
   }
 }

--- a/_gc/srv/srv.js
+++ b/_gc/srv/srv.js
@@ -446,6 +446,9 @@ function processOne(connection, u8mes) {
         const portdata = lockGPIO.get(portnum);
         portdata.exportobj = exportobj;
         logout(portnum + " dir: " + portdata.direction);
+        if (portdata.direction === 1) {
+          portdata.value = portdata.exportobj.readSync();
+        }
         lockGPIO.set(portnum, portdata);
         logout(
           "export:done: port=" + portnum + " direction=" + portdata.direction

--- a/_gc/srv/srv.js
+++ b/_gc/srv/srv.js
@@ -21,7 +21,7 @@ const port = 33330;
 
 const server = https.createServer({
   cert: fs.readFileSync("./crt/server.crt"),
-  key: fs.readFileSync("./crt/server.key")
+  key: fs.readFileSync("./crt/server.key"),
 });
 
 server.listen(port, () => {
@@ -123,7 +123,7 @@ const wss = new WebSocket.Server({ server });
 
 process.on("unhandledRejection", console.dir);
 
-wss.on("connection", ws => {
+wss.on("connection", (ws) => {
   var conn = {};
   conn.ws = ws;
   conn.uid = ws._socket._handle.fd;
@@ -137,7 +137,7 @@ wss.on("connection", ws => {
       (connections.size - 1)
   );
 
-  conn.ws.on("message", message => {
+  conn.ws.on("message", (message) => {
     var u8mes = new Uint8Array(message);
     processMessage(conn, u8mes);
   });
@@ -158,7 +158,7 @@ wss.on("connection", ws => {
 */
   });
 
-  conn.ws.on("error", error => {
+  conn.ws.on("error", (error) => {
     logout("[connection error]uid:" + conn.uid);
     conn.ws.terminate();
   });
@@ -171,7 +171,7 @@ function unlockAllResources({ exportedPorts, usingSlaveAddrs }) {
     tempGPIO.delete(key);
     lockGPIO.delete(key);
   });
-  usingSlaveAddrs.forEach(addr => {
+  usingSlaveAddrs.forEach((addr) => {
     logout("unlockAllResources-i2c:addr=" + addr);
     tempI2C.delete(addr);
   });
@@ -221,7 +221,7 @@ function checkAcquirable(connection, u8mes) {
             "x",
             "lockGPIO:",
             ["your uid", connection.uid].join(":"),
-            ["handle by", lockdata.uid].join(":")
+            ["handle by", lockdata.uid].join(":"),
           ].join(" ")
         );
         break;
@@ -237,7 +237,7 @@ function checkAcquirable(connection, u8mes) {
             "now processing",
             ["UID", `[${uid}]`].join(":"),
             ["session", `[${session}]`].join(":"),
-            ["waiting", u8mes].join(":")
+            ["waiting", u8mes].join(":"),
           ].join(" ")
         );
         acquire = 0;
@@ -261,7 +261,7 @@ function checkAcquirable(connection, u8mes) {
             "now processing",
             ["UID", `[${uid}]`].join(":"),
             ["session", `${session}`].join(":"),
-            ["waiting", u8mes].join(":")
+            ["waiting", u8mes].join(":"),
           ].join(" ")
         );
         acquire = 2;
@@ -315,7 +315,7 @@ function doProcess() {
         resolve(null);
       } else {
         // OK (aquirable)
-        processOne(probj.connection, probj.u8mes).then(value => {
+        processOne(probj.connection, probj.u8mes).then((value) => {
           //          logout("processOne.then() : "+processQueue.length);
 
           // Queueの処理実行時に入れ違いでWebSocketが閉じられていることがある。
@@ -339,7 +339,7 @@ const gpio = require("gpio", { interval: 50 });
 const i2c = require("i2c-bus");
 
 let i2c1 = null;
-i2c.openPromisified(1).then(bus => {
+i2c.openPromisified(1).then((bus) => {
   i2c1 = bus;
 });
 
@@ -432,7 +432,7 @@ function processOne(connection, u8mes) {
         lockGPIO.set(portnum, {
           uid: connection.uid,
           direction: direction,
-          value: -1
+          value: -1,
         });
         var dirStr;
         if (direction == 1) {
@@ -443,7 +443,7 @@ function processOne(connection, u8mes) {
         }
         var options = {
           direction: dirStr,
-          ready: function() {
+          ready: function () {
             temp.delete(portnum);
             var portdata = lockGPIO.get(portnum);
             portdata.exportobj = exportobj;
@@ -457,7 +457,7 @@ function processOne(connection, u8mes) {
             );
 
             if (portdata.direction == 1) {
-              portdata.exportobj.on("change", val => {
+              portdata.exportobj.on("change", (val) => {
                 // [0] Change Callback (2)
                 // [1] session id LSB (0)
                 // [2] session id MSB (0)
@@ -480,7 +480,7 @@ function processOne(connection, u8mes) {
               ans = createAnswer(u8mes, [1]);
               resolve(ans);
             }
-          }
+          },
         };
         var exportobj = gpio.export(portnum, options);
         connection.exportedPorts.set(portnum, exportobj);
@@ -567,7 +567,7 @@ function processOne(connection, u8mes) {
           [
             `0x20:[${session}]:`,
             `addr=${slaveAddress}`,
-            `method=${method}`
+            `method=${method}`,
           ].join(" ")
         );
 
@@ -607,7 +607,7 @@ function processOne(connection, u8mes) {
             `0x21:[${session}]:`,
             `addr=${slaveAddress}`,
             `size=${size}`,
-            `data.length=${data.length}`
+            `data.length=${data.length}`,
           ].join(" ")
         );
 
@@ -624,7 +624,7 @@ function processOne(connection, u8mes) {
             [
               `0x21:[${session}]:`,
               `addr=${slaveAddress}`,
-              `result=${bytesWritten}`
+              `result=${bytesWritten}`,
             ].join(" ")
           );
           temp.delete(slaveAddress);
@@ -654,7 +654,7 @@ function processOne(connection, u8mes) {
           [
             `0x22:[${session}]:`,
             `addr=${slaveAddress}`,
-            `readSize=${readSize}`
+            `readSize=${readSize}`,
           ].join(" ")
         );
 
@@ -666,7 +666,7 @@ function processOne(connection, u8mes) {
             [
               `0x22:[${session}]:`,
               `addr=${slaveAddress}`,
-              `result=${bytesRead}`
+              `result=${bytesRead}`,
             ].join(" ")
           );
           temp.delete(slaveAddress);
@@ -698,7 +698,7 @@ function processOne(connection, u8mes) {
             `0x23:[${session}]:`,
             `addr=${slaveAddress}`,
             `register=${registerNumber}`,
-            `readSize=${readSize}`
+            `readSize=${readSize}`,
           ].join(" ")
         );
 
@@ -710,7 +710,7 @@ function processOne(connection, u8mes) {
             [
               `0x23:[${session}]:`,
               `addr=${slaveAddress}`,
-              `result=${bytesRead}`
+              `result=${bytesRead}`,
             ].join(" ")
           );
           temp.delete(slaveAddress);

--- a/_gc/srv/srv.js
+++ b/_gc/srv/srv.js
@@ -69,7 +69,8 @@ var connections = new Map();
   obj.value       : GPIO value is LOW=0 or HIGH=1 or initializing=-1
 
 -------------------------------------------------------- */
-var lockGPIO = new Map();
+/** @type {Map<number, { uid: string, direction: 0 | 1, value: -1 | 0 | 1, exportobj: import("onoff").Gpio }>} */
+const lockGPIO = new Map();
 
 /* --------------------------------------------------------
 
@@ -335,7 +336,7 @@ function doProcess() {
 ////////////////////////////////////////////////////////////
 // GPIO / I2C wrapper
 
-const gpio = require("gpio", { interval: 50 });
+const Gpio = require("onoff").Gpio;
 const i2c = require("i2c-bus");
 
 let i2c1 = null;
@@ -434,55 +435,48 @@ function processOne(connection, u8mes) {
           direction: direction,
           value: -1,
         });
-        var dirStr;
-        if (direction == 1) {
-          // direction:in
-          dirStr = "in";
-        } else {
-          dirStr = "out";
-        }
-        var options = {
-          direction: dirStr,
-          ready: function () {
-            temp.delete(portnum);
-            var portdata = lockGPIO.get(portnum);
-            portdata.exportobj = exportobj;
-            logout(portnum + " dir: " + portdata.direction);
-            lockGPIO.set(portnum, portdata);
-            logout(
-              "export:done: port=" +
-                portnum +
-                " direction=" +
-                portdata.direction
-            );
+        const dirStr = direction === 1 ? "in" : "out";
+        const exportobj = new Gpio(
+          portnum,
+          dirStr,
+          dirStr === "in" ? "both" : undefined
+        );
 
-            if (portdata.direction == 1) {
-              portdata.exportobj.on("change", (val) => {
-                // [0] Change Callback (2)
-                // [1] session id LSB (0)
-                // [2] session id MSB (0)
-                // [3] function id (0x14)
-                // [4] Port Number
-                // [5] Value (0:LOW 1:HIGH)
-                logout("changed:" + portnum + " value:" + val);
-                var portdata = lockGPIO.get(portnum);
-                portdata.value = val;
-                lockGPIO.set(portnum, portdata);
-                var mes = new Uint8Array([2, 0, 0, 0x14, portnum, val]);
-                var conn = connections.get(portdata.uid);
-                conn.ws.send(mes);
-                mes = null;
-              });
-              ans = createAnswer(u8mes, [1]);
-              resolve(ans);
-            } else {
-              //         0     : export      : [4] result (1:OK, 0:NG)
-              ans = createAnswer(u8mes, [1]);
-              resolve(ans);
-            }
-          },
-        };
-        var exportobj = gpio.export(portnum, options);
+        temp.delete(portnum);
+        const portdata = lockGPIO.get(portnum);
+        portdata.exportobj = exportobj;
+        logout(portnum + " dir: " + portdata.direction);
+        lockGPIO.set(portnum, portdata);
+        logout(
+          "export:done: port=" + portnum + " direction=" + portdata.direction
+        );
+
+        if (portdata.direction == 1) {
+          portdata.exportobj.watch((err, val) => {
+            if (err) throw err;
+
+            // [0] Change Callback (2)
+            // [1] session id LSB (0)
+            // [2] session id MSB (0)
+            // [3] function id (0x14)
+            // [4] Port Number
+            // [5] Value (0:LOW 1:HIGH)
+            logout("changed:" + portnum + " value:" + val);
+            var portdata = lockGPIO.get(portnum);
+            portdata.value = val;
+            lockGPIO.set(portnum, portdata);
+            var mes = new Uint8Array([2, 0, 0, 0x14, portnum, val]);
+            var conn = connections.get(portdata.uid);
+            conn.ws.send(mes);
+            mes = null;
+          });
+          ans = createAnswer(u8mes, [1]);
+          resolve(ans);
+        } else {
+          //         0     : export      : [4] result (1:OK, 0:NG)
+          ans = createAnswer(u8mes, [1]);
+          resolve(ans);
+        }
         connection.exportedPorts.set(portnum, exportobj);
         break;
       }
@@ -504,11 +498,14 @@ function processOne(connection, u8mes) {
 
           logout("setValue() : port" + portnum + " value:" + value);
 
-          // setValue()
-          portdata.exportobj.set(value);
-          temp.delete(portnum);
-          ans = createAnswer(u8mes, [1]);
-          resolve(ans);
+          portdata.exportobj
+            .write(value)
+            .then(() => {
+              temp.delete(portnum);
+              ans = createAnswer(u8mes, [1]);
+              resolve(ans);
+            })
+            .catch(reject);
         } else {
           logout("setValue() Error : port[" + portnum + "] is now input port.");
         }
@@ -546,7 +543,7 @@ function processOne(connection, u8mes) {
       case 0x13: {
         logout("0x13:[" + session + "]: port=" + portnum);
         var portdata = lockGPIO.get(portnum);
-        portdata.exportobj.removeAllListeners("change");
+        portdata.exportobj.unwatchAll();
         portdata.exportobj.unexport();
         connection.exportedPorts.delete(portnum);
         lockGPIO.delete(portnum);


### PR DESCRIPTION
確認したこと:
- Node.js v14.17.4 環境で`node srv.js`を問題なく実行できる
    - https://tutorial.chirimen.org/raspi/section1 一通りパスする

やったこと:
- 05f8fdc 依存関係の変更: gpio→onoff
- cb2b50a fix #72

背景:

> > ここではLTS (2021-08-05 現在 v14)のインストール方法を示したが[gpioパッケージとの互換性に問題があるらしい](https://github.com/chirimen-oh/chirimen/pull/98)のでこれはあとで確認してみる
> 
> 再現した。
> 
> https://github.com/chirimen-oh/chirimen/blob/aa74b01e86c5a58acf14739f5980f84b8deac0eb/_gc/srv/srv.js#L485
> 
> ここのportnumにnumberを許容しないようになった。
> 
> https://github.com/chirimen-oh/chirimen/blob/aa74b01e86c5a58acf14739f5980f84b8deac0eb/_gc/srv/srv.js#L508
> 
> ここのvalueにいかなる値も許容しないようになった。number以外を与えるとgpioによってnumberに変換されエラーが発報する。
> [onoff](https://www.npmjs.com/package/onoff) あたりに置き換えたほうが良いと考える。